### PR TITLE
fix: check signed in user every other route changing

### DIFF
--- a/app/core/auth/auth-service.js
+++ b/app/core/auth/auth-service.js
@@ -4,10 +4,10 @@ angular
     '$rootScope', '$location', '$q', 'JwtService',
     function($rootScope, $location, $q , JwtService) {
       function redirectUnauthorizedUser() {
-        const isUserSignedIn = JwtService.getToken() !== null;
+        const isUserSignedIn = () => JwtService.getToken() !== null;
 
         $rootScope.$on('$routeChangeStart', (event, next ) => {
-          if(next.$$route?.private && !isUserSignedIn) 
+          if(next.$$route?.private && !isUserSignedIn()) 
             $location.path('/sign-in')
         })
       }


### PR DESCRIPTION
as mentioned at #1, There was a bug causing private route not to block its access when unauthorized user tries to request to it. The matter had been caused by `isUserSignedIn` variable. It was calling `getToken` method at `JwtService` and then saving its result. The problem is that it just verifies one single time and not on every route changing, causing it to hard coding the first value for the hole session.

### Solution
- previous
   ```js
   function redirectUnauthorizedUser() {
        const isUserSignedIn =  JwtService.getToken() !== null;

        $rootScope.$on('$routeChangeStart', (event, next ) => {
          if(next.$$route?.private && !isUserSignedIn()) 
            $location.path('/sign-in')
        })
   ```
- solved
   ```js
   function redirectUnauthorizedUser() {
        const isUserSignedIn = () => JwtService.getToken() !== null;

        $rootScope.$on('$routeChangeStart', (event, next ) => {
          if(next.$$route?.private && !isUserSignedIn()) 
            $location.path('/sign-in')
        })

   ```
