### PR TITLE
fix: user details persists after refresh

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -21,6 +21,9 @@ angular
     'AuthService',
     AuthService => AuthService.redirectUnauthorizedUser()
   ])
+  .constant('API_ENDPOINTS', {
+    HEROES: 'http://localhost:3000/heroes'
+  })
   .config(['$locationProvider', '$routeProvider', function($locationProvider, $routeProvider) {
     $locationProvider.hashPrefix('!');
 

--- a/app/core/heroes/heroes-service.js
+++ b/app/core/heroes/heroes-service.js
@@ -1,20 +1,11 @@
 angular
   .module('myApp.heroesService.service', [])
   .factory('HeroesService', [
-    '$resource',
+    '$resource', 'API_ENDPOINTS',
     class HeroesService {
-      heroes = [];
-      lastHero = {}
-  
-      constructor($resource) {
-        $resource('http://localhost:3000/heroes')
-          .query(heroes => this.#storeHeroesOnState(heroes));
-      }
-
-      #storeHeroesOnState(heroes) {
-        this.heroes.push(...heroes);
-        const lastHero = heroes.at(-1);
-        Object.assign(this.lastHero, lastHero);
+      constructor($resource, API_ENDPOINTS) {
+        this.heroes = $resource(API_ENDPOINTS.HEROES).query();
+        this.lastHero = {};
       }
 
       addNewHero(hero) {
@@ -22,8 +13,10 @@ angular
         Object.assign(this.lastHero, hero);
       }
 
-      findUserByUuid(uuid) {
-        return this.heroes.find(hero => hero.id === uuid)
+      findByUuid(uuid) {
+        return this.heroes.$promise.then(heroes => {
+          return heroes.find(hero => hero.id === uuid)
+        })
       }
     }
   ])

--- a/app/features/heroes/components/hero-details/hero-details.component.js
+++ b/app/features/heroes/components/hero-details/hero-details.component.js
@@ -5,7 +5,11 @@ angular
     controller: [
       '$routeParams', 'HeroesService', 
       function($routeParams, HeroesService) {
-        this.hero = HeroesService.findUserByUuid($routeParams.uuid);
+        this.hero = {}
+
+        HeroesService.findByUuid($routeParams.uuid)
+          .then(user => this.hero = user)
+          .catch(() => this.hero = false)
       }
     ]
   })


### PR DESCRIPTION
### Description

We observed that when a user signs in to the app and then accesses the `/heroes/:uuid` route, the hero details are displayed correctly. However, if the user refreshes the page, the app fails to show the hero details. The issue stems from the `hero details component` attempting to apply a query on the `heroes`model while it is still an empty array.

### Solution

We've changed the way how `Heroes service` stores the get request from API.
- heroes model now stores the request promise instead of assigning it as empty array and then assigning request result when it is done
- `findByUuid` method now waits for the heroes model to be done to return the query

### Testing steps

1. sign in at /sign-in
2. access /heroes route
3. access /heroes/:uuid by clicking on one of the heroes rendered at /heroes route
4. refresh the page

after these steps, the hero details must persist on the page.

[bug-solving-demo.webm](https://github.com/Th-Fernandes/angularjs-heroes/assets/74260107/fc0a6216-7b5a-4326-8a3c-30fbbb1bfbe6)



