### PR TITLE
Fix opportunities field wrongly sent

### DIFF
--- a/app/core/services/auth/auth.service.js
+++ b/app/core/services/auth/auth.service.js
@@ -50,8 +50,6 @@ angular
           .then(() => $q.resolve(true))
       }
 
-
-
       function signOut() {
         JwtService.removeToken();
         $location.path('/sign-in');
@@ -67,14 +65,10 @@ angular
     }
   ])
 
-
-
   class HeroModel {
     immutableFields = {
       id: uuidv4(),
-      opportunities: []
     }
-
     mutableFields = {
       name: {
         first: "",
@@ -105,7 +99,7 @@ angular
       for(let heroModelProperty of Object.keys(this.mutableFields)) {
         const isFieldMissing = !this.heroData.hasOwnProperty(heroModelProperty)
         if(isFieldMissing) {
-          this.errorMessage = `EXTERNAL ERROR: hero data recieved from sign up param method does not have "${heroModelProperty}" field`
+          this.errorMessage = `EXTERNAL ERROR: hero data received from sign up param method does not have "${heroModelProperty}" field`
           return isFieldMissing
         }
       }

--- a/app/features/sign-up/components/sign-up/sign-up-form.html
+++ b/app/features/sign-up/components/sign-up/sign-up-form.html
@@ -115,7 +115,7 @@
     <input type="password" ng-minlength="8" ng-model="$ctrl.inputs.password.value">
   </div>
 
-  <button type="submit" ng-disabled="$ctrl.signUpPromise.isLoading">
+  <button type="submit" ng-disabled="signUpForm.$invalid || $ctrl.signUpPromise.isLoading">
     Sign Up
   </button>
 </form>


### PR DESCRIPTION
### Description

as described in #17 issue, we are dealing with a huge matter here. It is crucial new registered heroes not to have opportunities field given that it is up to `/opportunities endpoint` to get such information. The new endpoint must the only source of retrieving opportunities data.

### tasks to-do

- [x] remove opportunities property from `Hero Model class` at `Auth Service`.
- [x] prevent user to send empty sign up by disabling submit button from `sign up component` when required fields are not full-filled yet  